### PR TITLE
Use column variable in train

### DIFF
--- a/src/tsdae/tsdae.py
+++ b/src/tsdae/tsdae.py
@@ -856,7 +856,7 @@ class TSDAE:
             # Constrain dataset
             constrained_data = self.constrain_dataset(
                 shuffled_dataset=shuffled_dataset,
-                column="output",
+                column=column,
                 splitter=splitter,
                 num_to_keep=num_to_keep,
                 total_sentences=total_sentences,


### PR DESCRIPTION
Thank you for making the training of a custom TSDAE instance straightforward. When trying this with a different column, I noticed that the column variable is ignored, this patch fixes that.